### PR TITLE
Make JS output configurable

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -15,7 +15,11 @@ module.exports = class HoganCompiler
   compile: (data, path, callback) ->
     try
       content = hogan.compile data, asString: yes
-      result = "module.exports = new Hogan.Template(#{content});"
+      if @config.hoganjs?
+        wrapper = @config.hoganjs.wrapper
+        if wrapper? and typeof wrapper = "function"
+          result = wrapper path, content
+      result = "module.exports = new Hogan.Template(#{content});" unless result?
     catch err
       error = err
     finally


### PR DESCRIPTION
I’m not using CommonJS or AMD in my project, but I still want Mustache templates with Hogan.js. It currently only exports CommonJS modules for compiled templates. I added a wrapper option which can configure the way it puts output in the final JS files.
